### PR TITLE
WebSocket 인증을 통한 인증받은 사용자끼리 메시지 전송 구현

### DIFF
--- a/client/src/main/java/cwchoiit/chat/client/ChatClient.java
+++ b/client/src/main/java/cwchoiit/chat/client/ChatClient.java
@@ -1,50 +1,46 @@
 package cwchoiit.chat.client;
 
-import cwchoiit.chat.client.dto.Message;
+import cwchoiit.chat.client.dto.MessageRequest;
+import cwchoiit.chat.client.handler.CommandHandler;
 import cwchoiit.chat.client.handler.WebSocketReceiverHandler;
 import cwchoiit.chat.client.handler.WebSocketSenderHandler;
+import cwchoiit.chat.client.service.RestApiService;
 import cwchoiit.chat.client.service.TerminalService;
 import cwchoiit.chat.client.service.WebSocketService;
 
 public class ChatClient {
     public static void main(String[] args) {
 
-        final String WEBSOCKET_BASE_URL = "localhost:8080";
+        final String BASE_URL = "localhost:8080";
         final String WEBSOCKET_ENDPOINT = "/ws/v1/message";
 
         TerminalService terminalService = TerminalService.create();
 
+        RestApiService restApiService = new RestApiService(terminalService, BASE_URL);
         WebSocketSenderHandler webSocketSenderHandler = new WebSocketSenderHandler(terminalService);
-        WebSocketService webSocketService = new WebSocketService(terminalService, webSocketSenderHandler, WEBSOCKET_BASE_URL, WEBSOCKET_ENDPOINT);
+        WebSocketService webSocketService = new WebSocketService(
+                terminalService,
+                webSocketSenderHandler,
+                BASE_URL,
+                WEBSOCKET_ENDPOINT
+        );
         webSocketService.setReceiverHandler(new WebSocketReceiverHandler(terminalService));
+        CommandHandler commandHandler = new CommandHandler(restApiService, webSocketService, terminalService);
 
         while (true) {
             String input = terminalService.readLine("Enter message:").trim();
             if (!input.isEmpty() && (input.charAt(0) == '/')) {
-                String command = input.substring(1);
+                String[] parts = input.split(" ", 2);
+                String command = parts[0].substring(1);
+                String argument = parts.length > 1 ? parts[1] : "";
 
-                boolean exit = switch (command) {
-                    case "exit" -> {
-                        webSocketService.closeSession();
-                        yield true;
-                    }
-                    case "clear" -> {
-                        terminalService.clearTerminal();
-                        yield false;
-                    }
-                    case "connect" -> {
-                        webSocketService.createSession();
-                        yield false;
-                    }
-                    default -> false;
-                };
-
-                if (exit) {
+                if (!commandHandler.process(command, argument)) {
                     break;
                 }
+
             } else if (!input.isEmpty()) {
                 terminalService.printMessage("[Me]", input);
-                webSocketService.sendMessage(new Message("[Client]", input));
+                webSocketService.sendMessage(new MessageRequest("[Client]", input));
             }
         }
     }

--- a/client/src/main/java/cwchoiit/chat/client/constants/MessageType.java
+++ b/client/src/main/java/cwchoiit/chat/client/constants/MessageType.java
@@ -1,0 +1,8 @@
+package cwchoiit.chat.client.constants;
+
+public interface MessageType {
+
+    String MESSAGE = "MESSAGE";
+    String KEEP_ALIVE = "KEEP_ALIVE";
+
+}

--- a/client/src/main/java/cwchoiit/chat/client/dto/BaseRequest.java
+++ b/client/src/main/java/cwchoiit/chat/client/dto/BaseRequest.java
@@ -1,0 +1,10 @@
+package cwchoiit.chat.client.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public abstract class BaseRequest {
+    private final String type;
+}

--- a/client/src/main/java/cwchoiit/chat/client/dto/KeepAliveRequest.java
+++ b/client/src/main/java/cwchoiit/chat/client/dto/KeepAliveRequest.java
@@ -1,0 +1,10 @@
+package cwchoiit.chat.client.dto;
+
+import cwchoiit.chat.client.constants.MessageType;
+
+public class KeepAliveRequest extends BaseRequest {
+
+    public KeepAliveRequest() {
+        super(MessageType.KEEP_ALIVE);
+    }
+}

--- a/client/src/main/java/cwchoiit/chat/client/dto/Message.java
+++ b/client/src/main/java/cwchoiit/chat/client/dto/Message.java
@@ -1,4 +1,0 @@
-package cwchoiit.chat.client.dto;
-
-public record Message(String username, String content) {
-}

--- a/client/src/main/java/cwchoiit/chat/client/dto/MessageRequest.java
+++ b/client/src/main/java/cwchoiit/chat/client/dto/MessageRequest.java
@@ -1,0 +1,20 @@
+package cwchoiit.chat.client.dto;
+
+import cwchoiit.chat.client.constants.MessageType;
+import lombok.Getter;
+
+@Getter
+public class MessageRequest extends BaseRequest {
+    private String username;
+    private String content;
+
+    public MessageRequest() {
+        super(MessageType.MESSAGE);
+    }
+
+    public MessageRequest(String username, String content) {
+        super(MessageType.MESSAGE);
+        this.username = username;
+        this.content = content;
+    }
+}

--- a/client/src/main/java/cwchoiit/chat/client/dto/UserRegisterRequest.java
+++ b/client/src/main/java/cwchoiit/chat/client/dto/UserRegisterRequest.java
@@ -1,0 +1,4 @@
+package cwchoiit.chat.client.dto;
+
+public record UserRegisterRequest(String username, String password) {
+}

--- a/client/src/main/java/cwchoiit/chat/client/handler/CommandHandler.java
+++ b/client/src/main/java/cwchoiit/chat/client/handler/CommandHandler.java
@@ -1,0 +1,89 @@
+package cwchoiit.chat.client.handler;
+
+import cwchoiit.chat.client.service.RestApiService;
+import cwchoiit.chat.client.service.TerminalService;
+import cwchoiit.chat.client.service.WebSocketService;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.function.Function;
+
+@RequiredArgsConstructor
+public class CommandHandler {
+    private final RestApiService restApiService;
+    private final WebSocketService webSocketService;
+    private final TerminalService terminalService;
+    private final Map<String, Function<String[], Boolean>> commands = Map.of(
+            "register", this::register,
+            "unregister", this::unregister,
+            "login", this::login,
+            "logout", this::logout,
+            "clear", this::clear,
+            "exit", this::exit
+    );
+
+
+    public boolean process(String command, String argument) {
+        Function<String[], Boolean> commander = commands.getOrDefault(command, (ignored) -> {
+            terminalService.printSystemMessage("Invalid command: %s".formatted(command));
+            return true;
+        });
+
+        return commander.apply(argument.split(" "));
+    }
+
+    private Boolean register(String[] params) {
+        if (params.length > 1) {
+            if (restApiService.register(params[0], params[1])) {
+                terminalService.printSystemMessage("Registered.");
+            } else {
+                terminalService.printSystemMessage("Failed to register.");
+            }
+        }
+        return true;
+    }
+
+    private Boolean unregister(String[] params) {
+        webSocketService.closeSession();
+        if (restApiService.unregister()) {
+            terminalService.printSystemMessage("Unregistered.");
+        } else {
+            terminalService.printSystemMessage("Failed to unregister.");
+        }
+        return true;
+    }
+
+    private Boolean login(String[] params) {
+        if (params.length > 1) {
+            if (restApiService.login(params[0], params[1])) {
+                if (webSocketService.createSession(restApiService.getSessionId())) {
+                    terminalService.printSystemMessage("Logged in.");
+                }
+            } else {
+                terminalService.printSystemMessage("Failed to login.");
+            }
+        }
+        return true;
+    }
+
+    private Boolean logout(String[] params) {
+        webSocketService.closeSession();
+        if (restApiService.logout()) {
+            terminalService.printSystemMessage("Logged out.");
+        } else {
+            terminalService.printSystemMessage("Failed to logout.");
+        }
+        return true;
+    }
+
+    private Boolean clear(String[] params) {
+        terminalService.clearTerminal();
+        return true;
+    }
+
+    private Boolean exit(String[] params) {
+        webSocketService.closeSession();
+        terminalService.printSystemMessage("Exiting...");
+        return false;
+    }
+}

--- a/client/src/main/java/cwchoiit/chat/client/handler/WebSocketReceiverHandler.java
+++ b/client/src/main/java/cwchoiit/chat/client/handler/WebSocketReceiverHandler.java
@@ -1,6 +1,6 @@
 package cwchoiit.chat.client.handler;
 
-import cwchoiit.chat.client.dto.Message;
+import cwchoiit.chat.client.dto.MessageRequest;
 import cwchoiit.chat.client.service.TerminalService;
 import cwchoiit.chat.serializer.Serializer;
 import jakarta.websocket.MessageHandler;
@@ -30,7 +30,7 @@ public class WebSocketReceiverHandler implements MessageHandler.Whole<String> {
 
     @Override
     public void onMessage(String payload) {
-        Serializer.deserialize(payload, Message.class)
-                .ifPresent(message -> terminalService.printMessage(message.username(), message.content()));
+        Serializer.deserialize(payload, MessageRequest.class)
+                .ifPresent(message -> terminalService.printMessage(message.getUsername(), message.getContent()));
     }
 }

--- a/client/src/main/java/cwchoiit/chat/client/handler/WebSocketSessionHandler.java
+++ b/client/src/main/java/cwchoiit/chat/client/handler/WebSocketSessionHandler.java
@@ -1,6 +1,7 @@
 package cwchoiit.chat.client.handler;
 
 import cwchoiit.chat.client.service.TerminalService;
+import cwchoiit.chat.client.service.WebSocketService;
 import jakarta.websocket.CloseReason;
 import jakarta.websocket.Endpoint;
 import jakarta.websocket.EndpointConfig;
@@ -28,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class WebSocketSessionHandler extends Endpoint {
 
     private final TerminalService terminalService;
+    private final WebSocketService webSocketService;
 
     @Override
     public void onOpen(Session session, EndpointConfig endpointConfig) {
@@ -36,6 +38,7 @@ public class WebSocketSessionHandler extends Endpoint {
 
     @Override
     public void onClose(Session session, CloseReason closeReason) {
+        webSocketService.closeSession();
         terminalService.printSystemMessage("WebSocket session close. Reason: " + closeReason.getReasonPhrase());
     }
 

--- a/client/src/main/java/cwchoiit/chat/client/service/RestApiService.java
+++ b/client/src/main/java/cwchoiit/chat/client/service/RestApiService.java
@@ -1,0 +1,89 @@
+package cwchoiit.chat.client.service;
+
+import cwchoiit.chat.client.dto.UserRegisterRequest;
+import cwchoiit.chat.serializer.Serializer;
+import lombok.Getter;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+
+@Getter
+public class RestApiService {
+
+    private final TerminalService terminalService;
+    private final String url;
+    private String sessionId;
+
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    public RestApiService(TerminalService terminalService, String url) {
+        this.terminalService = terminalService;
+        this.url = "http://%s".formatted(url);
+    }
+
+    public boolean register(String username, String password) {
+        return call("/api/v1/user/register", "", new UserRegisterRequest(username, password))
+                .map(response -> response.statusCode() == 200)
+                .orElse(false);
+    }
+
+    public boolean unregister() {
+        if (sessionId.isEmpty()) {
+            return false;
+        }
+
+        return call("/api/v1/user/unregister", sessionId, null)
+                .map(response -> response.statusCode() == 200)
+                .orElse(false);
+    }
+
+    public boolean login(String username, String password) {
+        return call("/api/v1/auth/login", "", new UserRegisterRequest(username, password))
+                .filter(response -> response.statusCode() == 200)
+                .map(response -> {
+                    sessionId = response.body();
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    public boolean logout() {
+        if (sessionId.isEmpty()) {
+            return false;
+        }
+
+        return call("/api/v1/auth/logout", sessionId, null)
+                .map(response -> response.statusCode() == 200)
+                .orElse(false);
+    }
+
+    private Optional<HttpResponse<String>> call(String path, String sessionId, Object body) {
+        try {
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                    .uri(new URI(url + path))
+                    .header("Content-Type", "application/json");
+
+            if (!sessionId.isEmpty()) {
+                builder.header("Cookie", "SESSION=" + sessionId);
+            }
+
+            if (body != null) {
+                Serializer.serialize(body).ifPresent(payload ->
+                        builder.POST(HttpRequest.BodyPublishers.ofString(payload))
+                );
+            } else {
+                builder.POST(HttpRequest.BodyPublishers.noBody());
+            }
+
+            HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+            terminalService.printSystemMessage("Response status: %d, body: %s".formatted(response.statusCode(), response.body()));
+            return Optional.of(response);
+        } catch (Exception e) {
+            terminalService.printSystemMessage("Failed to call API: " + e.getMessage());
+            return Optional.empty();
+        }
+    }
+}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -7,6 +7,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mysql'
 
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 

--- a/server/src/main/java/cwchoiit/chat/server/auth/RestApiLoginAuthFilter.java
+++ b/server/src/main/java/cwchoiit/chat/server/auth/RestApiLoginAuthFilter.java
@@ -1,7 +1,6 @@
 package cwchoiit.chat.server.auth;
 
 import cwchoiit.chat.serializer.Serializer;
-import cwchoiit.chat.server.dto.LoginRequest;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -18,6 +17,8 @@ import org.springframework.security.web.context.HttpSessionSecurityContextReposi
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 public class RestApiLoginAuthFilter extends AbstractAuthenticationProcessingFilter {
 
@@ -55,9 +56,12 @@ public class RestApiLoginAuthFilter extends AbstractAuthenticationProcessingFilt
         HttpSessionSecurityContextRepository contextRepository = new HttpSessionSecurityContextRepository();
         contextRepository.saveContext(context, request, response);
 
+        String sessionId = request.getSession().getId();
+        String encodedSessionId = Base64.getEncoder().encodeToString(sessionId.getBytes(StandardCharsets.UTF_8));
+
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(MediaType.TEXT_PLAIN_VALUE);
-        response.getWriter().write(request.getSession().getId());
+        response.getWriter().write(encodedSessionId);
         response.getWriter().flush();
     }
 
@@ -69,5 +73,8 @@ public class RestApiLoginAuthFilter extends AbstractAuthenticationProcessingFilt
         response.setContentType(MediaType.TEXT_PLAIN_VALUE);
         response.getWriter().write("Unauthorized");
         response.getWriter().flush();
+    }
+
+    public record LoginRequest(String username, String password) {
     }
 }

--- a/server/src/main/java/cwchoiit/chat/server/auth/WebSocketHttpSessionHandshakeInterceptor.java
+++ b/server/src/main/java/cwchoiit/chat/server/auth/WebSocketHttpSessionHandshakeInterceptor.java
@@ -1,0 +1,69 @@
+package cwchoiit.chat.server.auth;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
+
+import java.util.Map;
+
+import static cwchoiit.chat.server.constants.Constants.HTTP_SESSION_ID;
+
+/**
+ * This class is an implementation of {@link HttpSessionHandshakeInterceptor} responsible for intercepting
+ * WebSocket handshake requests. It ensures that an HTTP session exists before establishing a WebSocket
+ * connection and associates the session ID with the WebSocket session attributes.
+ * <p>
+ * By validating session existence before completing the handshake, this interceptor helps ensure
+ * that only authenticated users or requests with valid sessions can initiate WebSocket connections.
+ * If the session is null or the request is invalid, the handshake process is terminated with an
+ * appropriate HTTP status code.
+ * <p>
+ * This class uses Spring's WebSocket and HTTP abstraction libraries for request validation and
+ * response handling, and it is designed to work with a servlet-based web framework.
+ */
+@Slf4j
+@Component
+public class WebSocketHttpSessionHandshakeInterceptor extends HttpSessionHandshakeInterceptor {
+
+    /**
+     * Intercepts and processes an incoming WebSocket handshake request before the handshake is established.
+     * This method validates the existence of an HTTP session in the request and stores the session ID
+     * into the WebSocket attributes if the session exists. If the session does not exist, or if the
+     * request is invalid, the handshake process is terminated with an appropriate HTTP status code.
+     *
+     * @param request    the server-side HTTP request to validate, typically containing details about the handshake request
+     * @param response   the server-side HTTP response, typically used to modify or terminate the response if validation fails
+     * @param wsHandler  the handler for processing WebSocket messages, intercepted during the handshake phase
+     * @param attributes a map of WebSocket session attributes to be populated or accessed during the handshake process
+     * @return {@code true} if the handshake process is allowed to proceed, {@code false} otherwise
+     * @throws Exception if an error occurs during the handshake validation process
+     */
+    @Override
+    public boolean beforeHandshake(@NonNull ServerHttpRequest request,
+                                   @NonNull ServerHttpResponse response,
+                                   @NonNull WebSocketHandler wsHandler,
+                                   @NonNull Map<String, Object> attributes) throws Exception {
+        if (request instanceof ServletServerHttpRequest servletServerHttpRequest) {
+            HttpSession httpSession = servletServerHttpRequest.getServletRequest().getSession(false);
+            if (httpSession != null) { // 인증에 성공한 후 세션이 생성된 경우
+                attributes.put(HTTP_SESSION_ID.getValue(), httpSession.getId());
+                return true;
+            } else { // 인증 실패
+                log.warn("[beforeHandshake] WebSocket handshake failed. HttpSession is null. request: {}", servletServerHttpRequest.getServletRequest().getRequestURI());
+                response.setStatusCode(HttpStatus.UNAUTHORIZED);
+                return false;
+            }
+        } else { // Tomcat이 처리할 수 없는 요청인 경우
+            log.warn("[beforeHandshake] WebSocket handshake failed. request is not ServletServerHttpRequest. request: {}", request.getURI());
+            response.setStatusCode(HttpStatus.BAD_REQUEST);
+            return false;
+        }
+    }
+}

--- a/server/src/main/java/cwchoiit/chat/server/config/RedisSessionConfig.java
+++ b/server/src/main/java/cwchoiit/chat/server/config/RedisSessionConfig.java
@@ -6,12 +6,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.security.jackson2.SecurityJackson2Modules;
+import org.springframework.session.FlushMode;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 @Configuration
 @EnableRedisHttpSession(
         redisNamespace = "cwchoiit:chat:user:session",
-        maxInactiveIntervalInSeconds = 600
+        maxInactiveIntervalInSeconds = 600,
+        flushMode = FlushMode.IMMEDIATE // 속성을 변경하면 바로 변경내용 플러쉬
 )
 public class RedisSessionConfig {
 

--- a/server/src/main/java/cwchoiit/chat/server/config/SecurityConfig.java
+++ b/server/src/main/java/cwchoiit/chat/server/config/SecurityConfig.java
@@ -52,9 +52,10 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .addFilterAt(restApiLoginAuthFilter, UsernamePasswordAuthenticationFilter.class)
-                .authorizeHttpRequests(auth ->
-                        auth.requestMatchers("/api/v1/auth/login").permitAll()
-                                .anyRequest().authenticated()
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/auth/login").permitAll()
+                        .requestMatchers("/api/v1/user/register").permitAll()
+                        .anyRequest().authenticated()
                 )
                 .logout(logout ->
                         logout.logoutUrl("/api/v1/auth/logout").logoutSuccessHandler(this::logoutHandler)

--- a/server/src/main/java/cwchoiit/chat/server/config/WebSocketHandlerConfig.java
+++ b/server/src/main/java/cwchoiit/chat/server/config/WebSocketHandlerConfig.java
@@ -1,5 +1,6 @@
 package cwchoiit.chat.server.config;
 
+import cwchoiit.chat.server.auth.WebSocketHttpSessionHandshakeInterceptor;
 import cwchoiit.chat.server.handler.MessageHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -13,9 +14,11 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 public class WebSocketHandlerConfig implements WebSocketConfigurer {
 
     private final MessageHandler messageHandler;
+    private final WebSocketHttpSessionHandshakeInterceptor webSocketHttpSessionHandshakeInterceptor;
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(messageHandler, "/ws/v1/message");
+        registry.addHandler(messageHandler, "/ws/v1/message")
+                .addInterceptors(webSocketHttpSessionHandshakeInterceptor);
     }
 }

--- a/server/src/main/java/cwchoiit/chat/server/constants/Constants.java
+++ b/server/src/main/java/cwchoiit/chat/server/constants/Constants.java
@@ -1,0 +1,12 @@
+package cwchoiit.chat.server.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Constants {
+    HTTP_SESSION_ID("HTTP_SESSION_ID");
+
+    private final String value;
+}

--- a/server/src/main/java/cwchoiit/chat/server/constants/MessageType.java
+++ b/server/src/main/java/cwchoiit/chat/server/constants/MessageType.java
@@ -1,0 +1,8 @@
+package cwchoiit.chat.server.constants;
+
+public interface MessageType {
+
+    String MESSAGE = "MESSAGE";
+    String KEEP_ALIVE = "KEEP_ALIVE";
+
+}

--- a/server/src/main/java/cwchoiit/chat/server/controller/UserController.java
+++ b/server/src/main/java/cwchoiit/chat/server/controller/UserController.java
@@ -1,0 +1,34 @@
+package cwchoiit.chat.server.controller;
+
+import cwchoiit.chat.server.service.request.UserRegisterRequest;
+import cwchoiit.chat.server.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/register")
+    public ResponseEntity<String> register(@RequestBody UserRegisterRequest request) {
+        userService.createUser(request);
+        return ResponseEntity.ok("Registered.");
+    }
+
+    @PostMapping("/unregister")
+    public ResponseEntity<String> unregister(HttpServletRequest request) {
+        userService.removeUser();
+        request.getSession().invalidate();
+        return ResponseEntity.ok("Unregistered.");
+    }
+}

--- a/server/src/main/java/cwchoiit/chat/server/dto/LoginRequest.java
+++ b/server/src/main/java/cwchoiit/chat/server/dto/LoginRequest.java
@@ -1,4 +1,0 @@
-package cwchoiit.chat.server.dto;
-
-public record LoginRequest(String username, String password) {
-}

--- a/server/src/main/java/cwchoiit/chat/server/dto/MessageDto.java
+++ b/server/src/main/java/cwchoiit/chat/server/dto/MessageDto.java
@@ -1,4 +1,0 @@
-package cwchoiit.chat.server.dto;
-
-public record MessageDto(String username, String content) {
-}

--- a/server/src/main/java/cwchoiit/chat/server/handler/request/BaseRequest.java
+++ b/server/src/main/java/cwchoiit/chat/server/handler/request/BaseRequest.java
@@ -1,0 +1,22 @@
+package cwchoiit.chat.server.handler.request;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import cwchoiit.chat.server.constants.MessageType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type"
+)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = MessageRequest.class, name = MessageType.MESSAGE),
+        @JsonSubTypes.Type(value = KeepAliveRequest.class, name = MessageType.KEEP_ALIVE)
+})
+@RequiredArgsConstructor
+public abstract class BaseRequest {
+    private final String type;
+}

--- a/server/src/main/java/cwchoiit/chat/server/handler/request/KeepAliveRequest.java
+++ b/server/src/main/java/cwchoiit/chat/server/handler/request/KeepAliveRequest.java
@@ -1,0 +1,10 @@
+package cwchoiit.chat.server.handler.request;
+
+import cwchoiit.chat.server.constants.MessageType;
+
+public class KeepAliveRequest extends BaseRequest {
+
+    public KeepAliveRequest() {
+        super(MessageType.KEEP_ALIVE);
+    }
+}

--- a/server/src/main/java/cwchoiit/chat/server/handler/request/MessageRequest.java
+++ b/server/src/main/java/cwchoiit/chat/server/handler/request/MessageRequest.java
@@ -1,0 +1,19 @@
+package cwchoiit.chat.server.handler.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import cwchoiit.chat.server.constants.MessageType;
+import lombok.Getter;
+
+@Getter
+public class MessageRequest extends BaseRequest {
+    private final String username;
+    private final String content;
+
+    @JsonCreator
+    public MessageRequest(@JsonProperty("username") String username, @JsonProperty("content") String content) {
+        super(MessageType.MESSAGE);
+        this.username = username;
+        this.content = content;
+    }
+}

--- a/server/src/main/java/cwchoiit/chat/server/service/SessionService.java
+++ b/server/src/main/java/cwchoiit/chat/server/service/SessionService.java
@@ -1,0 +1,29 @@
+package cwchoiit.chat.server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.session.Session;
+import org.springframework.session.SessionRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class SessionService {
+
+    private final SessionRepository<? extends Session> sessionRepository;
+
+    public void refreshTimeToLive(String sessionId) {
+        Session httpSession = sessionRepository.findById(sessionId);
+        if (httpSession != null) {
+            httpSession.setLastAccessedTime(Instant.now());
+        }
+    }
+
+    public String findUsername() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication.getName();
+    }
+}

--- a/server/src/main/java/cwchoiit/chat/server/service/UserService.java
+++ b/server/src/main/java/cwchoiit/chat/server/service/UserService.java
@@ -1,0 +1,38 @@
+package cwchoiit.chat.server.service;
+
+import cwchoiit.chat.server.service.request.UserRegisterRequest;
+import cwchoiit.chat.server.entity.User;
+import cwchoiit.chat.server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final SessionService sessionService;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public Long createUser(UserRegisterRequest request) {
+        User newUser = userRepository.save(
+                User.create(
+                        request.username(),
+                        passwordEncoder.encode(request.password())
+                )
+        );
+        return newUser.getUserId();
+    }
+
+    @Transactional
+    public void removeUser() {
+        User findUser = userRepository.findByUsername(sessionService.findUsername()).orElseThrow();
+        userRepository.delete(findUser);
+    }
+}

--- a/server/src/main/java/cwchoiit/chat/server/service/request/UserRegisterRequest.java
+++ b/server/src/main/java/cwchoiit/chat/server/service/request/UserRegisterRequest.java
@@ -1,0 +1,4 @@
+package cwchoiit.chat.server.service.request;
+
+public record UserRegisterRequest(String username, String password) {
+}

--- a/server/src/test/java/cwchoiit/chat/server/MySqlTestContainer.java
+++ b/server/src/test/java/cwchoiit/chat/server/MySqlTestContainer.java
@@ -1,0 +1,19 @@
+package cwchoiit.chat.server;
+
+import org.testcontainers.containers.MySQLContainer;
+
+public class MySqlTestContainer {
+    private static final MySQLContainer<?> container;
+
+    static {
+        container = new MySQLContainer<>("mysql:8.0.38")
+                .withDatabaseName("test_db")
+                .withUsername("test")
+                .withPassword("test");
+        container.start();
+    }
+
+    public static MySQLContainer<?> getInstance() {
+        return container;
+    }
+}

--- a/server/src/test/java/cwchoiit/chat/server/SpringBootTestConfiguration.java
+++ b/server/src/test/java/cwchoiit/chat/server/SpringBootTestConfiguration.java
@@ -1,0 +1,21 @@
+package cwchoiit.chat.server;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@Transactional
+public class SpringBootTestConfiguration {
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        MySQLContainer<?> mysql = MySqlTestContainer.getInstance();
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("spring.datasource.driver-class-name", mysql::getDriverClassName);
+    }
+}

--- a/server/src/test/java/cwchoiit/chat/server/handler/MessageDtoHandlerTest.java
+++ b/server/src/test/java/cwchoiit/chat/server/handler/MessageDtoHandlerTest.java
@@ -1,7 +1,11 @@
 package cwchoiit.chat.server.handler;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import cwchoiit.chat.server.dto.MessageDto;
+import cwchoiit.chat.server.SpringBootTestConfiguration;
+import cwchoiit.chat.server.auth.RestApiLoginAuthFilter;
+import cwchoiit.chat.server.handler.request.MessageRequest;
+import cwchoiit.chat.server.service.request.UserRegisterRequest;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -10,13 +14,22 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.lang.NonNull;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketHttpHeaders;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
@@ -27,7 +40,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
-class MessageDtoHandlerTest {
+@Transactional
+class MessageDtoHandlerTest extends SpringBootTestConfiguration {
 
     @LocalServerPort
     int port;
@@ -43,7 +57,12 @@ class MessageDtoHandlerTest {
         private WebSocketSession session;
     }
 
-    static Client createClient(String url) throws ExecutionException, InterruptedException {
+    Client createClient(String sessionId) throws ExecutionException, InterruptedException, URISyntaxException {
+        String url = String.format("ws://localhost:%d/ws/v1/message", port);
+
+        WebSocketHttpHeaders webSocketHttpHeaders = new WebSocketHttpHeaders();
+        webSocketHttpHeaders.add("Cookie", "SESSION=%s".formatted(sessionId));
+
         StandardWebSocketClient client = new StandardWebSocketClient();
         BlockingQueue<String> queue = new ArrayBlockingQueue<>(10);
 
@@ -52,44 +71,97 @@ class MessageDtoHandlerTest {
             protected void handleTextMessage(@NonNull WebSocketSession session, @NonNull TextMessage message) throws Exception {
                 queue.put(message.getPayload());
             }
-        }, url).get();
+        }, webSocketHttpHeaders, new URI(url)).get();
 
         return new Client(queue, newSession);
     }
 
+    void register(String username, String password) throws JsonProcessingException {
+        String registerURL = String.format("http://localhost:%s/api/v1/user/register", port);
+
+        MultiValueMap<String, String> requestHeaders = new LinkedMultiValueMap<>();
+        requestHeaders.add("Content-Type", "application/json");
+
+        HttpHeaders httpHeaders = new HttpHeaders(requestHeaders);
+
+        UserRegisterRequest userRegisterRequest = new UserRegisterRequest(username, password);
+        String requestBody = objectMapper.writeValueAsString(userRegisterRequest);
+        HttpEntity<String> httpEntity = new HttpEntity<>(requestBody, httpHeaders);
+
+        new RestTemplate().postForEntity(registerURL, httpEntity, String.class);
+    }
+
+    void unregister(String sessionId) {
+        String registerURL = String.format("http://localhost:%s/api/v1/user/unregister", port);
+
+        MultiValueMap<String, String> requestHeaders = new LinkedMultiValueMap<>();
+        requestHeaders.add("Content-Type", "application/json");
+        requestHeaders.add("Cookie", String.format("SESSION=%s", sessionId));
+
+        HttpHeaders httpHeaders = new HttpHeaders(requestHeaders);
+
+        HttpEntity<UserRegisterRequest> httpEntity = new HttpEntity<>(httpHeaders);
+
+        new RestTemplate().postForEntity(registerURL, httpEntity, String.class);
+    }
+
+    String login(String username, String password) throws JsonProcessingException {
+        String loginURL = String.format("http://localhost:%s/api/v1/auth/login", port);
+        MultiValueMap<String, String> requestHeaders = new LinkedMultiValueMap<>();
+        requestHeaders.add("Content-Type", "application/json");
+        RestApiLoginAuthFilter.LoginRequest loginRequest = new RestApiLoginAuthFilter.LoginRequest(username, password);
+        String requestBody = objectMapper.writeValueAsString(loginRequest);
+        HttpEntity<String> httpEntity = new HttpEntity<>(requestBody, new HttpHeaders(requestHeaders));
+
+        return new RestTemplate().postForObject(loginURL, httpEntity, String.class);
+    }
+
     @Test
     @DisplayName("일대일 채팅 기본 연결 및 메시지 전송 테스트")
-    void directChat() throws ExecutionException, InterruptedException, IOException {
-        String url = String.format("ws://localhost:%d/ws/v1/message", port);
+    void directChat() throws ExecutionException, InterruptedException, IOException, URISyntaxException {
+        register("testUserA", "testUserAPassword");
+        register("testUserB", "testUserBPassword");
 
-        Client leftSession = createClient(url);
-        Client rightSession = createClient(url);
+        String sessionIdA = login("testUserA", "testUserAPassword");
+        String sessionIdB = login("testUserB", "testUserBPassword");
 
-        leftSession.getSession().sendMessage(new TextMessage(objectMapper.writeValueAsString(new MessageDto("leftSession", "안녕하세요"))));
-        rightSession.getSession().sendMessage(new TextMessage(objectMapper.writeValueAsString(new MessageDto("rightSession", "Hello"))));
+        Client userA = createClient(sessionIdA);
+        Client userB = createClient(sessionIdB);
 
-        String fromLeftMessage = rightSession.getQueue().poll(1, TimeUnit.SECONDS);
-        String fromRightMessage = leftSession.getQueue().poll(1, TimeUnit.SECONDS);
+        userA.getSession().sendMessage(new TextMessage(objectMapper.writeValueAsString(new MessageRequest("testUserA", "안녕하세요"))));
+        userB.getSession().sendMessage(new TextMessage(objectMapper.writeValueAsString(new MessageRequest("testUserB", "Hello"))));
+
+        String fromLeftMessage = userB.getQueue().poll(1, TimeUnit.SECONDS);
+        String fromRightMessage = userA.getQueue().poll(1, TimeUnit.SECONDS);
 
         assertThat(fromLeftMessage).contains("안녕하세요");
         assertThat(fromRightMessage).contains("Hello");
 
-        leftSession.getSession().close();
-        rightSession.getSession().close();
+        unregister(sessionIdA);
+        unregister(sessionIdB);
+
+        userA.getSession().close();
+        userB.getSession().close();
     }
 
     @Test
     @DisplayName("그룹 채팅 기본 테스트")
-    void groupChat() throws ExecutionException, InterruptedException, IOException {
-        String url = String.format("ws://localhost:%d/ws/v1/message", port);
+    void groupChat() throws ExecutionException, InterruptedException, IOException, URISyntaxException {
+        register("testUserA", "testUserAPassword");
+        register("testUserB", "testUserBPassword");
+        register("testUserC", "testUserCPassword");
 
-        Client sessionOne = createClient(url);
-        Client sessionTwo = createClient(url);
-        Client sessionThree = createClient(url);
+        String sessionIdA = login("testUserA", "testUserAPassword");
+        String sessionIdB = login("testUserB", "testUserBPassword");
+        String sessionIdC = login("testUserC", "testUserCPassword");
 
-        sessionOne.getSession().sendMessage(new TextMessage(objectMapper.writeValueAsString(new MessageDto("sessionOne", "Hello1"))));
-        sessionTwo.getSession().sendMessage(new TextMessage(objectMapper.writeValueAsString(new MessageDto("sessionTwo", "Hello2"))));
-        sessionThree.getSession().sendMessage(new TextMessage(objectMapper.writeValueAsString(new MessageDto("sessionThree", "Hello3"))));
+        Client sessionOne = createClient(sessionIdA);
+        Client sessionTwo = createClient(sessionIdB);
+        Client sessionThree = createClient(sessionIdC);
+
+        sessionOne.getSession().sendMessage(new TextMessage(objectMapper.writeValueAsString(new MessageRequest("sessionOne", "Hello1"))));
+        sessionTwo.getSession().sendMessage(new TextMessage(objectMapper.writeValueAsString(new MessageRequest("sessionTwo", "Hello2"))));
+        sessionThree.getSession().sendMessage(new TextMessage(objectMapper.writeValueAsString(new MessageRequest("sessionThree", "Hello3"))));
 
         String sessionOneReceivedMessage = sessionOne.getQueue().poll(1, TimeUnit.SECONDS) + sessionOne.getQueue().poll(1, TimeUnit.SECONDS);
         String sessionTwoReceivedMessage = sessionTwo.getQueue().poll(1, TimeUnit.SECONDS) + sessionTwo.getQueue().poll(1, TimeUnit.SECONDS);
@@ -108,6 +180,10 @@ class MessageDtoHandlerTest {
         assertThat(sessionOne.getQueue().isEmpty()).isTrue();
         assertThat(sessionTwo.getQueue().isEmpty()).isTrue();
         assertThat(sessionThree.getQueue().isEmpty()).isTrue();
+
+        unregister(sessionIdA);
+        unregister(sessionIdB);
+        unregister(sessionIdC);
 
         sessionOne.getSession().close();
         sessionTwo.getSession().close();

--- a/server/src/test/resources/application.yaml
+++ b/server/src/test/resources/application.yaml
@@ -1,0 +1,5 @@
+spring:
+  sql:
+    init:
+      mode: always
+      encoding: UTF-8

--- a/server/src/test/resources/schema.sql
+++ b/server/src/test/resources/schema.sql
@@ -1,0 +1,17 @@
+create table if not exists message
+(
+    message_sequence bigint        not null auto_increment primary key,
+    username         varchar(30)   not null comment '유저명',
+    content          varchar(1000) not null comment '메시지 내용',
+    created_at       datetime      not null comment '생성 일자',
+    updated_at       datetime      not null comment '수정 일자'
+);
+
+create table if not exists user
+(
+    user_id    bigint       not null auto_increment primary key,
+    username   varchar(30)  not null unique comment '유저명',
+    password   varchar(255) not null comment '패스워드',
+    created_at datetime     not null comment '생성 일자',
+    updated_at datetime     not null comment '수정 일자'
+)


### PR DESCRIPTION
- 회원가입을 하고 로그인을 하면 로그인 성공 시 세션을 응답받음
- 해당 세션은 Redis에 저장되고, 이 세션을 통해 유저 관리 시작
- 로그인 성공 후, 세션을 응답으로 받으면 유저는 해당 세션을 WebSocket 커넥션 요청에 쿠키로 넣어서 업그레이드 요청을 날림
- HTTP -> WebSocket으로 HandShake하기 전, WebSocketHttpSessionHandshakeInterceptor가 호출
- 인터셉터에서는 요청에 포함된 HTTP 세션을 가져와야하고, 없다면 인증되지 않은 유저로 판단하고 튕김. 있다면 해당 HTTP 세션을 WebSocket 세션의 속성값으로 저장한 후 HandShake 진행
- 이 세션은 Redis에 저장되고, TTL이 존재하므로, 메시지 창에서 메시지를 계속 보내는 유저들은 이 TTL을 주기적으로 갱신해야함. 갱신하기 위한 SessionService.refreshTimeToLive()로 구현
- 클라이언트 쪽에서는 로그인 요청을 날리고 세션을 생성하는데, 세션을 생성할 때 WebSocketService.enableKeepAlive() 스케쥴러를 통해 이 refreshTimeToLive()를 지속적으로 호출 (세션이 살아있는 경우에만)
